### PR TITLE
Fix missing twitter attr

### DIFF
--- a/users/templates/json/user.json
+++ b/users/templates/json/user.json
@@ -6,5 +6,7 @@
   "email_updates": {{ user.email_updates }},
   "latitude": {{ user.latitude }},
   "longitude": {{ user.longitude }},
+  {% if user.social_account %}
   "twitter": "{{ user.social_account.twitter }}"
+  {% endif %}
 }


### PR DESCRIPTION
This changeset hides `user.social_account.twitter` if users doesn't set their twitter handle.
